### PR TITLE
security: CVE scan (dependencies clean) + pin alpine build base image

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=$BUILDPLATFORM alpine AS ruby-community-build
+# Pin the base image to an immutable digest (alpine 3.24.1) so the build cannot
+# silently pull a newer, potentially vulnerable `alpine:latest`. This stage is
+# only used to assemble files into the final scratch image; no OS packages ship.
+FROM --platform=$BUILDPLATFORM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS ruby-community-build
 WORKDIR /opentelemetry-ruby
 ARG TARGETARCH
 ARG RUBY_VERSIONS="3.1 3.2 3.3 3.4"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Performed a comprehensive CVE scan of the repository and addressed the one actionable supply-chain finding. **No vulnerable Ruby dependencies were found** in the shipped gem bundle (the trace-collection artifact), so no gem versions were changed — eliminating any risk to trace collection.

## CVE scan results

The pinned Ruby gems (all 8 `*/{amd64,arm64}/Gemfile.lock` files and the vendored `bundle/`) were scanned with four independent, current sources:

| Source | Result |
| --- | --- |
| **Trivy** (DB updated 2026-06-25) | 0 vulnerabilities across all 8 lockfiles |
| **OSV.dev** (`osv-scanner` 2.4.0) | "No issues found" |
| **ruby-advisory-db** (rubysec, fresh clone) | No applicable advisories — `google-protobuf 4.33.5`, `rake 13.3.1`, `bundler 4.0.6` are all far newer than any advisory range |
| **Published image** `public.ecr.aws/odigos/agents/ruby-community:latest` | 0 vulnerabilities (the live shipped artifact) |

The gem set (OpenTelemetry SDK/API/instrumentations, `google-protobuf`, `googleapis-common-protos-types`, `bigdecimal`, `rake`) is already up to date and free of known CVEs.

## What this PR changes

The only actionable security finding came from Trivy's Dockerfile config scan: `release.Dockerfile` used a floating `alpine` (implicit `:latest`) base image (`DS-0001`). This PR pins it to an immutable digest:

```
FROM --platform=$BUILDPLATFORM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
```

This prevents the build from silently pulling a future, potentially vulnerable base image. The stage only assembles files into the final `scratch` image, so **no shipped gem is touched and trace collection is unaffected**.

The remaining config-scan items (`DS-0002` non-root `USER`, `DS-0026` `HEALTHCHECK`) are not applicable to a `scratch` filesystem-only image — the build stages must run as root to write under `/`, and there is no runtime process to health-check.

## Verifying trace collection

The e2e CI (`tests.yaml`, runs on `pull_request`) exercises end-to-end trace collection across Ruby 3.1–3.4 against an OpenTelemetry Collector. Because this PR does not modify the gem bundle or `index.rb`, a green run confirms trace collection remains intact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc0f24af-2fc7-41ae-b94f-c6092ff67280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc0f24af-2fc7-41ae-b94f-c6092ff67280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

emergency-ticket id: EMR-1953
